### PR TITLE
Ignore readonly files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ This plugin is an autosaver for Neovim that automatically saves all of your chan
 - to offer at least some customization via options, as well as the ability to easily enable/disable
 - to be better or more correct than `CursorHold` autosavers and not depend on `CursorHold` if feasible
 
+### Additional Features
+
+- has its own independent timer, distinct from `'updatetime'`, which may be set to any value in ms
+- timer is only started/reset on buffer changes, not cursor movements or other irrelevant events
+- keeps buffers in sync with the filesystem by frequently running `:checktime` in the background for you (e.g. on `CTRL-Z` or suspend, resume, command, etc.)
+- intelligently ignores `'readonly'` and other such unwritable buffers/files (i.e. the writing of files with insufficient permissions must be attempted manually with `:w`)
+
 For any questions, help with setup, or general help, you can try [discussions][q&a]. For issues, bugs, apparent bugs, or feature requests, feel free to [open an issue][issues] or [create a pull request][prs].
 
 ## Installation

--- a/lua/sos/impl.lua
+++ b/lua/sos/impl.lua
@@ -23,6 +23,12 @@ M.savable_cmdline = vim.regex [=[system\|:lua\|[Jj][Oo][Bb]]=]
 local recognized_buftypes =
     vim.regex [[\%(^$\)\|\%(^\%(acwrite\|help\|nofile\|nowrite\|quickfix\|terminal\|prompt\)$\)]]
 
+---@param val any
+---@return boolean
+local function tobool(val)
+    return val == true or val == 1
+end
+
 ---@param buf integer
 ---@nodiscard
 ---@return boolean
@@ -125,6 +131,14 @@ function M.write_buf_if_needed(buf)
                     end
 
                     -- Parent dir exists but isn't writeable.
+                    return true
+                elseif dir_errname == "ENOENT" then
+                    if tobool(vim.fn.mkdir(dir, "p")) then
+                        return write_buf(buf)
+                    end
+
+                    -- Parent dir doesn't exist, failed to create it (e.g.
+                    -- perms).
                     return true
                 end
             end


### PR DESCRIPTION
It is not enough to just check vim's `'ro'` option and only write a buffer when it is unset. For one, `'ro'` may be (or become) unset even when the file is unwritable. By default, vim also unsets `'ro'` after writing a readonly buffer, regardless of whether the file permissions have changed or not (see also the `Z` flag from the `'cpo'` option). Even when unset, vim will prompt (or error if `'confirm'` is unset) every time to write a buffer whose file has insufficient permissions to do a simple write (i.e. a write w/o resorting to a `cp` or `mv` of the file), which can quickly become annoying when the writing is done frequently/automatically.

### Additional Comments

In the future, consider allowing the user to opt-into forcefully writing readonly buffers. There could also be an option to ignore any resulting errors in this case as well. These options might not be very safe though, and they would require `W` to be absent from `'cpo'`.